### PR TITLE
feat(cms): Create Strapi Content Types for Devices and Studios

### DIFF
--- a/src/api/connection/content-types/connection/schema.json
+++ b/src/api/connection/content-types/connection/schema.json
@@ -1,0 +1,57 @@
+{
+  "kind": "collectionType",
+  "collectionName": "connections",
+  "info": {
+    "singularName": "connection",
+    "pluralName": "connections",
+    "displayName": "Connection",
+    "description": "Connection between device ports in a studio"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "studio": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::studio.studio",
+      "inversedBy": "connections"
+    },
+    "sourceDeviceId": {
+      "type": "string",
+      "required": true
+    },
+    "sourcePortId": {
+      "type": "string",
+      "required": true
+    },
+    "targetDeviceId": {
+      "type": "string",
+      "required": true
+    },
+    "targetPortId": {
+      "type": "string",
+      "required": true
+    },
+    "cableType": {
+      "type": "enumeration",
+      "enum": [
+        "midi",
+        "audio",
+        "power",
+        "cv",
+        "gate",
+        "clock",
+        "usb",
+        "ethernet"
+      ]
+    },
+    "notes": {
+      "type": "text"
+    },
+    "color": {
+      "type": "string"
+    }
+  }
+}

--- a/src/api/connection/controllers/connection.ts
+++ b/src/api/connection/controllers/connection.ts
@@ -1,0 +1,7 @@
+/**
+ * connection controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::connection.connection')

--- a/src/api/connection/routes/connection.ts
+++ b/src/api/connection/routes/connection.ts
@@ -1,0 +1,7 @@
+/**
+ * connection router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::connection.connection');

--- a/src/api/connection/services/connection.ts
+++ b/src/api/connection/services/connection.ts
@@ -1,0 +1,7 @@
+/**
+ * connection service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::connection.connection');

--- a/src/api/device/content-types/device/schema.json
+++ b/src/api/device/content-types/device/schema.json
@@ -1,0 +1,70 @@
+{
+  "kind": "collectionType",
+  "collectionName": "devices",
+  "info": {
+    "singularName": "device",
+    "pluralName": "devices",
+    "displayName": "Device",
+    "description": "Music hardware device"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true,
+      "unique": false
+    },
+    "manufacturer": {
+      "type": "string",
+      "required": true
+    },
+    "model": {
+      "type": "string",
+      "required": true
+    },
+    "type": {
+      "type": "enumeration",
+      "enum": [
+        "synthesizer",
+        "drum_machine",
+        "audio_interface",
+        "eurorack_module",
+        "controller",
+        "effect",
+        "mixer",
+        "monitor"
+      ],
+      "required": true
+    },
+    "releaseYear": {
+      "type": "integer",
+      "min": 1950,
+      "max": 2100
+    },
+    "description": {
+      "type": "text"
+    },
+    "imageUrl": {
+      "type": "string"
+    },
+    "manualUrl": {
+      "type": "string"
+    },
+    "ports": {
+      "type": "json",
+      "required": false
+    },
+    "tags": {
+      "type": "json"
+    },
+    "studios": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::studio.studio",
+      "inversedBy": "devices"
+    }
+  }
+}

--- a/src/api/device/controllers/device.ts
+++ b/src/api/device/controllers/device.ts
@@ -1,0 +1,7 @@
+/**
+ * device controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::device.device')

--- a/src/api/device/routes/device.ts
+++ b/src/api/device/routes/device.ts
@@ -1,0 +1,7 @@
+/**
+ * device router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::device.device');

--- a/src/api/device/services/device.ts
+++ b/src/api/device/services/device.ts
@@ -1,0 +1,7 @@
+/**
+ * device service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::device.device');

--- a/src/api/studio/content-types/studio/schema.json
+++ b/src/api/studio/content-types/studio/schema.json
@@ -1,0 +1,47 @@
+{
+  "kind": "collectionType",
+  "collectionName": "studios",
+  "info": {
+    "singularName": "studio",
+    "pluralName": "studios",
+    "displayName": "Studio",
+    "description": "User studio setup with devices and connections"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text"
+    },
+    "userId": {
+      "type": "string",
+      "required": true
+    },
+    "devices": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::device.device",
+      "inversedBy": "studios"
+    },
+    "connections": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::connection.connection",
+      "mappedBy": "studio"
+    },
+    "layout": {
+      "type": "json",
+      "required": false
+    },
+    "viewport": {
+      "type": "json",
+      "required": false
+    }
+  }
+}

--- a/src/api/studio/controllers/studio.ts
+++ b/src/api/studio/controllers/studio.ts
@@ -1,0 +1,7 @@
+/**
+ * studio controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::studio.studio')

--- a/src/api/studio/routes/studio.ts
+++ b/src/api/studio/routes/studio.ts
@@ -1,0 +1,7 @@
+/**
+ * studio router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::studio.studio');

--- a/src/api/studio/services/studio.ts
+++ b/src/api/studio/services/studio.ts
@@ -1,0 +1,7 @@
+/**
+ * studio service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::studio.studio');


### PR DESCRIPTION
## Summary
Complete Strapi CMS content types for Dawly platform with relations and GraphQL API.

## Changes
- ✅ Device content type (8 device types)
- ✅ Studio content type with user relation
- ✅ Connection content type for device connections
- ✅ Many-to-many relation: Studio ↔ Device
- ✅ One-to-many relation: Studio → Connection
- ✅ JSON fields for ports, layout, viewport
- ✅ REST API routes (auto-generated)
- ✅ GraphQL API (auto-generated)
- ✅ Core controllers and services

## Content Types

### Device
- name, manufacturer, model, type
- releaseYear (1950-2100)
- description, imageUrl, manualUrl
- ports (JSON): array of connection ports
- tags (JSON): device tags
- studios: many-to-many relation

### Studio
- name, description, userId
- devices: many-to-many relation
- connections: one-to-many relation
- layout (JSON): React Flow node positions
- viewport (JSON): canvas viewport state

### Connection
- sourceDeviceId, sourcePortId
- targetDeviceId, targetPortId
- cableType: enum (midi, audio, power, cv, gate, clock, usb, ethernet)
- notes, color
- studio: many-to-one relation

## API Endpoints

**REST API:**
- GET/POST /api/devices
- GET/PUT/DELETE /api/devices/:id
- GET/POST /api/studios
- GET/PUT/DELETE /api/studios/:id
- GET/POST /api/connections
- GET/PUT/DELETE /api/connections/:id

**GraphQL:**
- Auto-generated queries and mutations
- Relation resolvers
- Filtering and pagination

## Next Steps
- Configure RBAC permissions
- Add custom resolvers for complex queries
- Frontend GraphQL integration (#13)

## Review Request
@codex review - Strapi content types

Closes #1